### PR TITLE
2D rsp's with PDF model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ env:
         # Try all python versions with the latest numpy
         - SETUP_CMD='test'
 
-          
 matrix:
     include:
 
@@ -72,7 +71,6 @@ matrix:
           env: NUMPY_VERSION=1.7
         - python: 3.5
           env: NUMPY_VERSION=1.10
-
 
 install:
 

--- a/docs/gen_plots.py
+++ b/docs/gen_plots.py
@@ -1,6 +1,5 @@
 from astropy.modeling.fitting import SherpaFitter
 from astropy.modeling.models import Gaussian1D, Gaussian2D
-
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,7 @@ To make use of the entry points plugin registry which automatically makes the |S
 Otherwise one can just use the latest stable ``astropy`` via::  
    conda install astropy
 
+
 Next install Sherpa_ using the conda ``sherpa`` channel.  Note that Sherpa
 currently needs to be installed after astropy on Mac OSX.
 
@@ -236,4 +237,8 @@ API/Reference
 Credit
 ------
 
-The development of this package was made possible by the generous support of the `Google Summer of Code <https://summerofcode.withgoogle.com/>`_ program in 2016 under the `OpenAstronomy <http://openastronomy.org/>`_ by `Michele Costa <https://github.com/nocturnalastro>`_ with the support and advice of mentors `Tom Aldcroft <https://github.com/taldcroft>`_, `Omar Laurino <https://github.com/olaurino>`_, `Moritz Guenther <https://github.com/hamogu>`_, and `Doug Burke <https://github.com/DougBurke>`_. 
+The development of this package was made possible by the generous support of the `Google Summer of Code <https://summerofcode.withgoogle.com/>`_ program in 2016 
+under the `OpenAstronomy <http://openastronomy.org/>`_ 
+by `Michele Costa <https://github.com/nocturnalastro>`_ with the support and advice of mentors 
+`Tom Aldcroft <https://github.com/taldcroft>`_, `Omar Laurino <https://github.com/olaurino>`_, 
+`Moritz Guenther <https://github.com/hamogu>`_, and `Doug Burke <https://github.com/DougBurke>`_. 

--- a/saba/main.py
+++ b/saba/main.py
@@ -290,27 +290,24 @@ def make_rsp(data,rsp):
     except AttributeError:
         ndims = len(data.data.get_dims())
 
-    if ndims > 1:
-        return None
-    else:
-        rsp = np.asarray(rsp)
+    rsp = np.asarray(rsp)
 
-        if data.ndata > 1:
-            if rsp.ndim > 1 or rsp.dtype == np.object:
-                if rsp.shape[0] == data.ndata:
-                    zipped = zip(data.data.datasets, rsp)
-                else:
-                    raise AstropyUserWarning("There is more than 1 but not"
-                                             " ndata responses")
+    if data.ndata > 1:
+        if rsp.ndim > 1 or rsp.dtype == np.object:
+            if rsp.shape[0] == data.ndata:
+                zipped = zip(data.data.datasets, rsp)
             else:
-                zipped = zip(data.data.datasets,
-                             [rsp for _ in xrange(data.ndata)])
-
-            rsp = []
-            for da, rr in zipped:
-                rsp.append(wrap_rsp(da, rr))
+                raise AstropyUserWarning("There is more than 1 but not"
+                                         " ndata responses")
         else:
-            return wrap_rsp(data.data, rsp)
+            zipped = zip(data.data.datasets,
+                         [rsp for _ in xrange(data.ndata)])
+
+        rsp = []
+        for da, rr in zipped:
+            rsp.append(wrap_rsp(da, rr))
+    else:
+        return wrap_rsp(data.data, rsp)
 
 
 class SherpaFitter(Fitter):

--- a/saba/tests/coveragerc
+++ b/saba/tests/coveragerc
@@ -18,7 +18,7 @@ exclude_lines =
    pragma: no cover
 
    # Don't complain about packages we have installed
-   # except ImportError
+   except ImportError
 
    # Don't complain if tests don't hit assertions
    raise AssertionError

--- a/saba/tests/test_main.py
+++ b/saba/tests/test_main.py
@@ -289,6 +289,21 @@ class TestSherpaFitter(object):
         sfit(m, x, y, bkg=bkg)
         # TODO: Make this better!
 
+
+    def test_rsp1d_doesnt_explode(self):
+        """
+        Check this goes through the motions
+        """
+
+        self.fitter(self.model1d.copy(), self.x1, self.y1, err=self.dy1, rsp=self.rsp1)
+
+    def test_rsp1d_multi_doesnt_explode(self):
+        """
+        Check this goes through the motions
+        """
+
+        self.fitter([self.model1d.copy(), self.model1d_2.copy()], [self.x1, self.x2], [self.y1, self.y2], err=[self.dy1, self.dy2], rsp=[self.rsp1, self.rsp2])
+
     def test_entry_points(self):
         # a little to test that entry points can be loaded!
         from pkg_resources import iter_entry_points

--- a/saba/tests/test_main.py
+++ b/saba/tests/test_main.py
@@ -304,6 +304,12 @@ class TestSherpaFitter(object):
 
         self.fitter([self.model1d.copy(), self.model1d_2.copy()], [self.x1, self.x2], [self.y1, self.y2], err=[self.dy1, self.dy2], rsp=[self.rsp1, self.rsp2])
 
+    def test_rsp2d_doesnt_explode(self):
+        """
+        Check this goes through the motions
+        """
+        self.fitter(self.model2d.copy(), self.xx1, self.xx2, self.yy, err=self.dyy, rsp=self.rsp2d)
+
     def test_entry_points(self):
         # a little to test that entry points can be loaded!
         from pkg_resources import iter_entry_points


### PR DESCRIPTION
If a rsp is supplied then the model is wrapped in a sherpa PSF model. This is only done to the sherpa fit model and not the input/returned astropy model.

This currently fails as`_tcd.convolve` gives the error
`TypeError: input array size do not match dimensions, source size: 100 vs source dim: 10000`
a bit of digging reveals that the kernel becomes this size from 100 to 10000 in the `init_kernel` function.
I haven't looked into anymore than this,.
