### PR TITLE
[WIP] Split models or Supplied list - how to share parameters across models?

### DIFF
--- a/saba/models.py
+++ b/saba/models.py
@@ -1,0 +1,145 @@
+from astropy.modeling.core import FittableModel
+
+
+class Split(FittableModel):
+    """
+    Allows inputs to be split into multiple outputs based on indexs
+
+    Parameters
+    ----------
+    split_indexes : tuple
+        A tuple of integers representing indices on which the input 
+        array will be split
+    name : str, optional
+        A human-friendly name associated with this model instance
+        (particularly useful for identifying the individual components of a
+        compound model).
+    meta : dict-like
+        Free-form metadata to associate with this model.
+
+    """
+    def __init__(self, split_indexes, name=None, meta=None):
+        self._inputs = tuple('x')
+        self._outputs = tuple('x' + str(idx) for idx in \
+                              range(len(split_indexes)+1))
+        self._split_indexes = split_indexes
+        super(Split, self).__init__(name=name, meta=meta)
+    
+    def _format_expression(self):
+        first = "x[:{0}]".format(self._split_indexes[0])
+        last = "x[{0}:]".format(self._split_indexes[-1])
+        if self.n_outputs > 1:
+            middle = ["x[{0}:{1}]".format(*indexes) for indexes in zip(self._split_indexes[:-1], self._split_indexes[1:])]
+            return ", ".join([first] + middle + [last])
+        else:
+            
+            return ", ".join([first, last])
+        
+    @property
+    def split_indexes(self):
+        """Integers representing indices of the inputs."""
+        return self._split_indexes
+    
+    @property
+    def inputs(self):
+        """
+        The name(s) of the input variable(s) on which a model is evaluated.
+        """
+        return self._inputs
+
+    @property
+    def outputs(self):
+        """The name(s) of the output(s) of the model."""
+        return self._outputs
+
+    
+    def __repr__(self):
+        
+        if self.name is None:
+            return '<SplitInput1D {0})>'.format(self._format_expression())
+        else:
+            return '<SplitInput1D({0}, name={1})>'.format(self._format_expression(), self.name)
+    
+    def evaluate(self, x):
+        first = x[:self._split_indexes[0]]
+        last = x[self._split_indexes[-1]:]
+        if self.n_outputs>2:
+            middle=[x[indexes[0]:indexes[1]] for indexes in zip(self._split_indexes[:-1], self._split_indexes[1:])]
+            return [first] + middle + [last]
+        else:
+            return [first, last]
+    
+    def __call__(self, x):
+        return self.evaluate(x)
+
+
+class Join(FittableModel):
+    """
+    Flattens output
+
+    Parameters
+    ----------
+    n_inputs : int
+        We need to tell it how many inputs to expect.
+    name : str, optional
+        A human-friendly name associated with this model instance
+        (particularly useful for identifying the individual components of a
+        compound model).
+    meta : dict-like
+        Free-form metadata to associate with this model.
+
+    """
+    
+    def __init__(self, n_inputs, name=None, meta=None):
+        self._inputs = tuple('x' + str(idx) for idx in range(n_inputs+1))
+        self._outputs=tuple("x")
+        super(Join, self).__init__(name=name, meta=meta)
+ 
+    @property
+    def inputs(self):
+        """
+        The name(s) of the input variable(s) on which a model is evaluated.
+        """
+        return self._inputs
+
+    @property
+    def outputs(self):
+        """The name(s) of the output(s) of the model."""
+        return self._outputs
+    
+    def evaluate(self, *x):
+        return np.hstack(x)
+    
+    def __call__(self, *x):
+        return self.__call__(x)
+
+
+def model_split_join(xvals, models):
+    ''' This returns a compound model which allows the
+    tying of parameters. the input values xvals should be
+    flattened before passing into the returned model.
+
+    Parameters
+    ----------
+    xvals: list of arrays
+        arrays of input coordinates which should then
+        be flattend and input
+
+    models: a list of `astropy.modeling.core.FittableModel`
+        the models which are combined
+
+    Returns
+    -------
+    combined_model: an instance of `astropy.modeling.core.FittableModel`
+    '''
+
+    if len(models) > 1:
+        split_indexes = []
+        for xx in xvals:
+            split_indexes.append(len(xx))
+        splitin = Split(split_indexes)
+        joinout = Join(len(split_indexes))
+        mo = model[0]
+        for m in models[1:]:
+            mo &= m
+        return splitin | mo | joinout

--- a/saba/models.py
+++ b/saba/models.py
@@ -24,7 +24,7 @@ class Split(FittableModel):
                               range(len(split_indexes)+1))
         self._split_indexes = split_indexes
         super(Split, self).__init__(name=name, meta=meta)
-    
+
     def _format_expression(self):
         first = "x[:{0}]".format(self._split_indexes[0])
         last = "x[{0}:]".format(self._split_indexes[-1])
@@ -32,14 +32,13 @@ class Split(FittableModel):
             middle = ["x[{0}:{1}]".format(*indexes) for indexes in zip(self._split_indexes[:-1], self._split_indexes[1:])]
             return ", ".join([first] + middle + [last])
         else:
-            
             return ", ".join([first, last])
-        
+
     @property
     def split_indexes(self):
         """Integers representing indices of the inputs."""
         return self._split_indexes
-    
+
     @property
     def inputs(self):
         """
@@ -52,14 +51,13 @@ class Split(FittableModel):
         """The name(s) of the output(s) of the model."""
         return self._outputs
 
-    
+
     def __repr__(self):
-        
         if self.name is None:
             return '<SplitInput1D {0})>'.format(self._format_expression())
         else:
             return '<SplitInput1D({0}, name={1})>'.format(self._format_expression(), self.name)
-    
+
     def evaluate(self, x):
         first = x[:self._split_indexes[0]]
         last = x[self._split_indexes[-1]:]
@@ -68,7 +66,7 @@ class Split(FittableModel):
             return [first] + middle + [last]
         else:
             return [first, last]
-    
+
     def __call__(self, x):
         return self.evaluate(x)
 
@@ -89,12 +87,12 @@ class Join(FittableModel):
         Free-form metadata to associate with this model.
 
     """
-    
+
     def __init__(self, n_inputs, name=None, meta=None):
         self._inputs = tuple('x' + str(idx) for idx in range(n_inputs+1))
         self._outputs=tuple("x")
         super(Join, self).__init__(name=name, meta=meta)
- 
+
     @property
     def inputs(self):
         """
@@ -106,10 +104,10 @@ class Join(FittableModel):
     def outputs(self):
         """The name(s) of the output(s) of the model."""
         return self._outputs
-    
+
     def evaluate(self, *x):
         return np.hstack(x)
-    
+
     def __call__(self, *x):
         return self.__call__(x)
 
@@ -137,6 +135,13 @@ def model_split_join(xvals, models):
         split_indexes = []
         for xx in xvals:
             split_indexes.append(len(xx))
+
+        runnning_total = 0
+	# the xvals should be flattend so.
+        for n,ll in enumerate(split_indexes):
+            running_total += ll
+            split_indexes[n] = running_total
+
         splitin = Split(split_indexes)
         joinout = Join(len(split_indexes))
         mo = model[0]


### PR DESCRIPTION
We have two solutions to astropy models only allowing parameters to other parameters in the model which owns them.
The first is presented in the code, is two [mapping-like](http://docs.astropy.org/en/stable/modeling/compound-models.html#compound-model-mappings) models (Split and Join) which can be used to create compound models with a list of models as in [`model_split_join`](https://github.com/astropy/saba/commit/f0f9ab3ba3e14429b9c4bd18dd1e77b82ebde520#diff-947e1ffc9d9fda8d76357c421445ced5R117).
Split separates input based on known indexes allowing each submodel to act on separate parts of the input. 
This is demonstrated in this [notebook](https://github.com/nocturnalastro/astrosherpa-notebooks/blob/proofofconcept/Split_input_compound_model.ipynb).

The second solution is akin to that of astropy's [JointFitter](https://github.com/astropy/astropy/blob/master/astropy/modeling/fitting.py#L755) which takes a list of parameter pairs to join, this can be seen in this [notebook](https://github.com/nocturnalastro/astrosherpa-notebooks/blob/master/Tied_List_Fitter.ipynb). This solution will clearly have less overhead but is perhaps a bit less flexible as anything more than simple this equals this could get tricky.

@taldcroft @hamogu @olaurino @DougBurke (sorry for the spam)
Did we decide which solution was best during GSOC? 
I can't remember and the notes don't seem to mention a preference.