### PR TITLE
Updates for astropy 3+ etc al.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,9 +107,9 @@ matrix:
         - os: linux
           env: NUMPY_VERSION=1.14
 
-        # Try numpy pre-release
+        # Try numpy dev
         - os: linux
-          env: NUMPY_VERSION=prerelease
+          env: NUMPY_VERSION=dev
                EVENT_TYPE='pull_request push cron'
 
         # Do a PEP8 test with flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,18 @@
-language: python
+# We set the language to c because python isn't supported on the MacOS X nodes
+# on Travis. However, the language ends up being irrelevant anyway, since we
+# install Python ourselves using conda.
+language: c
 
-python:
-    - 2.7
-    - 3.5
+os:
+    - linux
 
+# Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
+
+# The apt packages below are needed for sphinx builds. A full list of packages
+# that can be included can be found here:
+#
+# https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
 
 addons:
     apt:
@@ -12,57 +20,137 @@ addons:
             - graphviz
             - texlive-latex-extra
             - dvipng
-            - gfortran
 
 env:
     global:
+
+        # The following versions are the 'default' for tests, unless
+        # overridden underneath. They are defined here in order to save having
+        # to repeat them for all configurations.
+        - PYTHON_VERSION=3.7
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
+        - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
-        - CONDA_DEPENDENCIES='sherpa'
-        - CONDA_CHANNELS='sherpa'
+        - EVENT_TYPE='pull_request push'
+
+        
+        # For this package-template, we include examples of Cython modules,
+        # so Cython is required for testing. If your package does not include
+        # Cython code, you can set CONDA_DEPENDENCIES=''
+        - CONDA_DEPENDENCIES='Cython sherpa'
+        - CONDA_DEPENDENCIES_DOC='Cython sphinx-astropy sherpa'
+        
+        # List other runtime dependencies for the package that are available as
+        # pip packages here.
+        - PIP_DEPENDENCIES=''
+
+        # Conda packages for affiliated packages are hosted in channel
+        # "astropy" while builds for astropy LTS with recent numpy versions
+        # are in astropy-ci-extras. If your package uses either of these,
+        # add the channels to CONDA_CHANNELS along with any other channels
+        # you want to use.
+        - CONDA_CHANNELS='astropy-ci-extras astropy sherpa'
+
+        # If there are matplotlib or other GUI tests, uncomment the following
+        # line to use the X virtual framebuffer.
+        # - SETUP_XVFB=True
+
+        # If you want to ignore certain flake8 errors, you can list them
+        # in FLAKE8_OPT, for example:
+        # - FLAKE8_OPT='--ignore=E501'
+        - FLAKE8_OPT=''
 
     matrix:
-        - SETUP_CMD='egg_info'
+        # Make sure that egg_info works without dependencies
+        - PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
+            - gfortran
+
 
 matrix:
-    include:
 
-        # Do a coverage test in Python 2.
-        - python: 2.7
+    # Don't wait for allowed failures
+    fast_finish: true
+
+    include:
+        # Try MacOS X
+        - os: osx
+          env: SETUP_CMD='test'
+
+        # Do a coverage test.
+        - os: linux
           env: SETUP_CMD='test --coverage'
 
-        # Sherpa 4.8.2 is the first to support python
-        - python: 3.5
-          env: SHERPA_VERSION>=4.8.2 
+        # Check for sphinx doc build warnings - we do this first because it
+        # may run for a long time
+        - os: linux
+          env: SETUP_CMD='build_docs -w'
+               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_DOC
 
-        - python: 3.5
-          env: SHERPA_VERSION>=4.8.2 ASTROPY_VERSION=dev
+        # Now try Astropy dev with the latest Python and LTS with Python 2.7 and 3.x.
+        - os: linux
+          env: ASTROPY_VERSION=development
+               EVENT_TYPE='pull_request push cron'
+        - os: linux
+          env: ASTROPY_VERSION=lts
 
-        # Testing the docs building
-        - python: 3.5
-          env: SHERPA_VERSION>=4.8.2 SETUP_CMD='build_sphinx -w'
-               CONDA_DEPENDENCIES='sherpa ipython'
+        # Try all python versions and Numpy versions. Since we can assume that
+        # the Numpy developers have taken care of testing Numpy with different
+        # versions of Python, we can vary Python and Numpy versions at the same
+        # time.
 
-        # Test old numpy versions
-        - python: 3.5
-          env: SHERPA_VERSION>=4.8.2 NUMPY_VERSION=1.10
-        - python: 2.7
-          env: NUMPY_VERSION=1.9
-        - python: 2.7
-          env: NUMPY_VERSION=1.8
+        - os: linux
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.12
+        - os: linux
+          env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.13
+        - os: linux
+          env: NUMPY_VERSION=1.14
 
+        # Try numpy pre-release
+        - os: linux
+          env: NUMPY_VERSION=prerelease
+               EVENT_TYPE='pull_request push cron'
+
+        # Do a PEP8 test with flake8
+        - os: linux
+          env: MAIN_CMD='flake8 packagename --count --show-source --statistics $FLAKE8_OPT' SETUP_CMD=''
+
+    allow_failures:
+        # Do a PEP8 test with flake8
+        # (allow to fail unless your code completely compliant)
+        - os: linux
+          env: MAIN_CMD='flake8 packagename --count --show-source --statistics $FLAKE8_OPT' SETUP_CMD=''
+	  
 install:
-    - git clone git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+
+    # We now use the ci-helpers package to set up our testing environment.
+    # This is done by using Miniconda and then using conda and pip to install
+    # dependencies. Which dependencies are installed using conda and pip is
+    # determined by the CONDA_DEPENDENCIES and PIP_DEPENDENCIES variables,
+    # which should be space-delimited lists of package names. See the README
+    # in https://github.com/astropy/ci-helpers for information about the full
+    # list of environment variables that can be used to customize your
+    # environment. In some cases, ci-helpers may not offer enough flexibility
+    # in how to install a package, in which case you can have additional
+    # commands in the install: section below.
+
+    - git clone --depth 1 git://github.com/astropy/ci-helpers.git
+    - source ci-helpers/travis/setup_conda.sh
+
+    # As described above, using ci-helpers, you should be able to set up an
+    # environment with dependencies installed using conda and pip, but in some
+    # cases this may not provide enough flexibility in how to install a
+    # specific dependency (and it will not be able to install non-Python
+    # dependencies). Therefore, you can also include commands below (as
+    # well as at the start of the install section or in the before_install
+    # section if they are needed before setting up conda) to install any
+    # other dependencies.
 
 script:
-    - python setup.py $SETUP_CMD
+   - $MAIN_CMD $SETUP_CMD
 
 after_success:
-    - if [[ $SETUP_CMD == 'test --coverage' ]]; then
-         coveralls --rcfile='saba/tests/coveragerc';
-      fi
+    - if [[ $SETUP_CMD == *coverage* ]]; then coveralls --rcfile='saba/tests/coveragerc'; fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ addons:
             - graphviz
             - texlive-latex-extra
             - dvipng
+            - gfortran
 
 env:
     global:
@@ -120,7 +121,7 @@ matrix:
         # (allow to fail unless your code completely compliant)
         - os: linux
           env: MAIN_CMD='flake8 packagename --count --show-source --statistics $FLAKE8_OPT' SETUP_CMD=''
-	  
+
 install:
 
     # We now use the ci-helpers package to set up our testing environment.

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -19,9 +19,14 @@ that section, and options therein, determine the next step taken:  If it
 contains an option called ``auto_use`` with a value of ``True``, it will
 automatically call the main function of this module called
 `use_astropy_helpers` (see that function's docstring for full details).
-Otherwise no further action is taken (however,
-``ah_bootstrap.use_astropy_helpers`` may be called manually from within the
-setup.py script).
+Otherwise no further action is taken and by default the system-installed version
+of astropy-helpers will be used (however, ``ah_bootstrap.use_astropy_helpers``
+may be called manually from within the setup.py script).
+
+This behavior can also be controlled using the ``--auto-use`` and
+``--no-auto-use`` command-line flags. For clarity, an alias for
+``--no-auto-use`` is ``--use-system-astropy-helpers``, and we recommend using
+the latter if needed.
 
 Additional options in the ``[ah_boostrap]`` section of setup.cfg have the same
 names as the arguments to `use_astropy_helpers`, and can be used to configure
@@ -33,7 +38,6 @@ latest version of this module.
 
 import contextlib
 import errno
-import imp
 import io
 import locale
 import os
@@ -41,55 +45,116 @@ import re
 import subprocess as sp
 import sys
 
-try:
-    from ConfigParser import ConfigParser, RawConfigParser
-except ImportError:
-    from configparser import ConfigParser, RawConfigParser
+from distutils import log
+from distutils.debug import DEBUG
 
+from configparser import ConfigParser, RawConfigParser
 
-if sys.version_info[0] < 3:
-    _str_types = (str, unicode)
-    _text_type = unicode
-    PY3 = False
+import pkg_resources
+
+from setuptools import Distribution
+from setuptools.package_index import PackageIndex
+
+# This is the minimum Python version required for astropy-helpers
+__minimum_python_version__ = (3, 5)
+
+# TODO: Maybe enable checking for a specific version of astropy_helpers?
+DIST_NAME = 'astropy-helpers'
+PACKAGE_NAME = 'astropy_helpers'
+UPPER_VERSION_EXCLUSIVE = None
+
+# Defaults for other options
+DOWNLOAD_IF_NEEDED = True
+INDEX_URL = 'https://pypi.python.org/simple'
+USE_GIT = True
+OFFLINE = False
+AUTO_UPGRADE = True
+
+# A list of all the configuration options and their required types
+CFG_OPTIONS = [
+    ('auto_use', bool), ('path', str), ('download_if_needed', bool),
+    ('index_url', str), ('use_git', bool), ('offline', bool),
+    ('auto_upgrade', bool)
+]
+
+# Start off by parsing the setup.cfg file
+
+SETUP_CFG = ConfigParser()
+
+if os.path.exists('setup.cfg'):
+
+    try:
+        SETUP_CFG.read('setup.cfg')
+    except Exception as e:
+        if DEBUG:
+            raise
+
+        log.error(
+            "Error reading setup.cfg: {0!r}\n{1} will not be "
+            "automatically bootstrapped and package installation may fail."
+            "\n{2}".format(e, PACKAGE_NAME, _err_help_msg))
+
+# We used package_name in the package template for a while instead of name
+if SETUP_CFG.has_option('metadata', 'name'):
+    parent_package = SETUP_CFG.get('metadata', 'name')
+elif SETUP_CFG.has_option('metadata', 'package_name'):
+    parent_package = SETUP_CFG.get('metadata', 'package_name')
 else:
-    _str_types = (str, bytes)
-    _text_type = str
-    PY3 = True
+    parent_package = None
+
+if SETUP_CFG.has_option('options', 'python_requires'):
+
+    python_requires = SETUP_CFG.get('options', 'python_requires')
+
+    # The python_requires key has a syntax that can be parsed by SpecifierSet
+    # in the packaging package. However, we don't want to have to depend on that
+    # package, so instead we can use setuptools (which bundles packaging). We
+    # have to add 'python' to parse it with Requirement.
+
+    from pkg_resources import Requirement
+    req = Requirement.parse('python' + python_requires)
+
+    # We want the Python version as a string, which we can get from the platform module
+    import platform
+    # strip off trailing '+' incase this is a dev install of python
+    python_version = platform.python_version().strip('+')
+    # allow pre-releases to count as 'new enough'
+    if not req.specifier.contains(python_version, True):
+        if parent_package is None:
+            message = "ERROR: Python {} is required by this package\n".format(req.specifier)
+        else:
+            message = "ERROR: Python {} is required by {}\n".format(req.specifier, parent_package)
+        sys.stderr.write(message)
+        sys.exit(1)
+
+if sys.version_info < __minimum_python_version__:
+
+    if parent_package is None:
+        message = "ERROR: Python {} or later is required by astropy-helpers\n".format(
+            __minimum_python_version__)
+    else:
+        message = "ERROR: Python {} or later is required by astropy-helpers for {}\n".format(
+            __minimum_python_version__, parent_package)
+
+    sys.stderr.write(message)
+    sys.exit(1)
+
+_str_types = (str, bytes)
 
 
 # What follows are several import statements meant to deal with install-time
 # issues with either missing or misbehaving pacakges (including making sure
 # setuptools itself is installed):
 
+# Check that setuptools 30.3 or later is present
+from distutils.version import LooseVersion
 
-# Some pre-setuptools checks to ensure that either distribute or setuptools >=
-# 0.7 is used (over pre-distribute setuptools) if it is available on the path;
-# otherwise the latest setuptools will be downloaded and bootstrapped with
-# ``ez_setup.py``.  This used to be included in a separate file called
-# setuptools_bootstrap.py; but it was combined into ah_bootstrap.py
 try:
-    import pkg_resources
-    _setuptools_req = pkg_resources.Requirement.parse('setuptools>=0.7')
-    # This may raise a DistributionNotFound in which case no version of
-    # setuptools or distribute is properly installed
-    _setuptools = pkg_resources.get_distribution('setuptools')
-    if _setuptools not in _setuptools_req:
-        # Older version of setuptools; check if we have distribute; again if
-        # this results in DistributionNotFound we want to give up
-        _distribute = pkg_resources.get_distribution('distribute')
-        if _setuptools != _distribute:
-            # It's possible on some pathological systems to have an old version
-            # of setuptools and distribute on sys.path simultaneously; make
-            # sure distribute is the one that's used
-            sys.path.insert(1, _distribute.location)
-            _distribute.activate()
-            imp.reload(pkg_resources)
-except:
-    # There are several types of exceptions that can occur here; if all else
-    # fails bootstrap and use the bootstrapped version
-    from ez_setup import use_setuptools
-    use_setuptools()
-
+    import setuptools
+    assert LooseVersion(setuptools.__version__) >= LooseVersion('30.3')
+except (ImportError, AssertionError):
+    sys.stderr.write("ERROR: setuptools 30.3 or later is required by astropy-helpers\n")
+    sys.exit(1)
 
 # typing as a dependency for 1.6.1+ Sphinx causes issues when imported after
 # initializing submodule with ah_boostrap.py
@@ -132,36 +197,6 @@ except:
 # End compatibility imports...
 
 
-# In case it didn't successfully import before the ez_setup checks
-import pkg_resources
-
-from setuptools import Distribution
-from setuptools.package_index import PackageIndex
-from setuptools.sandbox import run_setup
-
-from distutils import log
-from distutils.debug import DEBUG
-
-
-# TODO: Maybe enable checking for a specific version of astropy_helpers?
-DIST_NAME = 'astropy-helpers'
-PACKAGE_NAME = 'astropy_helpers'
-
-# Defaults for other options
-DOWNLOAD_IF_NEEDED = True
-INDEX_URL = 'https://pypi.python.org/simple'
-USE_GIT = True
-OFFLINE = False
-AUTO_UPGRADE = True
-
-# A list of all the configuration options and their required types
-CFG_OPTIONS = [
-    ('auto_use', bool), ('path', str), ('download_if_needed', bool),
-    ('index_url', str), ('use_git', bool), ('offline', bool),
-    ('auto_upgrade', bool)
-]
-
-
 class _Bootstrapper(object):
     """
     Bootstrapper implementation.  See ``use_astropy_helpers`` for parameter
@@ -177,7 +212,7 @@ class _Bootstrapper(object):
         if not (isinstance(path, _str_types) or path is False):
             raise TypeError('path must be a string or False')
 
-        if PY3 and not isinstance(path, _text_type):
+        if not isinstance(path, str):
             fs_encoding = sys.getfilesystemencoding()
             path = path.decode(fs_encoding)  # path to unicode
 
@@ -231,36 +266,20 @@ class _Bootstrapper(object):
 
     @classmethod
     def parse_config(cls):
-        if not os.path.exists('setup.cfg'):
-            return {}
 
-        cfg = ConfigParser()
-
-        try:
-            cfg.read('setup.cfg')
-        except Exception as e:
-            if DEBUG:
-                raise
-
-            log.error(
-                "Error reading setup.cfg: {0!r}\n{1} will not be "
-                "automatically bootstrapped and package installation may fail."
-                "\n{2}".format(e, PACKAGE_NAME, _err_help_msg))
-            return {}
-
-        if not cfg.has_section('ah_bootstrap'):
+        if not SETUP_CFG.has_section('ah_bootstrap'):
             return {}
 
         config = {}
 
         for option, type_ in CFG_OPTIONS:
-            if not cfg.has_option('ah_bootstrap', option):
+            if not SETUP_CFG.has_option('ah_bootstrap', option):
                 continue
 
             if type_ is bool:
-                value = cfg.getboolean('ah_bootstrap', option)
+                value = SETUP_CFG.getboolean('ah_bootstrap', option)
             else:
-                value = cfg.get('ah_bootstrap', option)
+                value = SETUP_CFG.get('ah_bootstrap', option)
 
             config[option] = value
 
@@ -286,6 +305,18 @@ class _Bootstrapper(object):
         if '--offline' in argv:
             config['offline'] = True
             argv.remove('--offline')
+
+        if '--auto-use' in argv:
+            config['auto_use'] = True
+            argv.remove('--auto-use')
+
+        if '--no-auto-use' in argv:
+            config['auto_use'] = False
+            argv.remove('--no-auto-use')
+
+        if '--use-system-astropy-helpers' in argv:
+            config['auto_use'] = False
+            argv.remove('--use-system-astropy-helpers')
 
         return config
 
@@ -464,9 +495,10 @@ class _Bootstrapper(object):
             # setup.py exists we can generate it
             setup_py = os.path.join(path, 'setup.py')
             if os.path.isfile(setup_py):
-                with _silence():
-                    run_setup(os.path.join(path, 'setup.py'),
-                              ['egg_info'])
+                # We use subprocess instead of run_setup from setuptools to
+                # avoid segmentation faults - see the following for more details:
+                # https://github.com/cython/cython/issues/2104
+                sp.check_output([sys.executable, 'setup.py', 'egg_info'], cwd=path)
 
                 for dist in pkg_resources.find_distributions(path, True):
                     # There should be only one...
@@ -501,16 +533,32 @@ class _Bootstrapper(object):
         if version:
             req = '{0}=={1}'.format(DIST_NAME, version)
         else:
-            req = DIST_NAME
+            if UPPER_VERSION_EXCLUSIVE is None:
+                req = DIST_NAME
+            else:
+                req = '{0}<{1}'.format(DIST_NAME, UPPER_VERSION_EXCLUSIVE)
 
         attrs = {'setup_requires': [req]}
 
+        # NOTE: we need to parse the config file (e.g. setup.cfg) to make sure
+        # it honours the options set in the [easy_install] section, and we need
+        # to explicitly fetch the requirement eggs as setup_requires does not
+        # get honored in recent versions of setuptools:
+        # https://github.com/pypa/setuptools/issues/1273
+
         try:
-            if DEBUG:
-                _Distribution(attrs=attrs)
-            else:
-                with _silence():
-                    _Distribution(attrs=attrs)
+
+            context = _verbose if DEBUG else _silence
+            with context():
+                dist = _Distribution(attrs=attrs)
+                try:
+                    dist.parse_config_files(ignore_option_errors=True)
+                    dist.fetch_build_eggs(req)
+                except TypeError:
+                    # On older versions of setuptools, ignore_option_errors
+                    # doesn't exist, and the above two lines are not needed
+                    # so we can just continue
+                    pass
 
             # If the setup_requires succeeded it will have added the new dist to
             # the main working_set
@@ -620,8 +668,8 @@ class _Bootstrapper(object):
         # only if the submodule is initialized.  We ignore this information for
         # now
         _git_submodule_status_re = re.compile(
-            '^(?P<status>[+-U ])(?P<commit>[0-9a-f]{40}) '
-            '(?P<submodule>\S+)( .*)?$')
+            r'^(?P<status>[+-U ])(?P<commit>[0-9a-f]{40}) '
+            r'(?P<submodule>\S+)( .*)?$')
 
         # The stdout should only contain one line--the status of the
         # requested submodule
@@ -791,9 +839,9 @@ def run_cmd(cmd):
         stdio_encoding = 'latin1'
 
     # Unlikely to fail at this point but even then let's be flexible
-    if not isinstance(stdout, _text_type):
+    if not isinstance(stdout, str):
         stdout = stdout.decode(stdio_encoding, 'replace')
-    if not isinstance(stderr, _text_type):
+    if not isinstance(stderr, str):
         stderr = stderr.decode(stdio_encoding, 'replace')
 
     return (p.returncode, stdout, stderr)
@@ -845,6 +893,10 @@ class _DummyFile(object):
     def flush(self):
         pass
 
+
+@contextlib.contextmanager
+def _verbose():
+    yield
 
 @contextlib.contextmanager
 def _silence():

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -183,7 +183,7 @@ renamed_rst_epilog = """
 .. _AstroPy: http://www.astropy.org/
 .. _matplotlib: http://matplotlib.org/
 .. _Sphinx: http://sphinx.pocoo.org/
-
+.. _Sherpa: http://cxc.cfa.harvard.edu/contrib/sherpa/
 """
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ import os
 # pre-installed, rather than something that cna be bootstrap-installed
 # during the documentation-build process).
 #
-from astropy_helpers.sphinx.conf import *
+from sphinx_astropy.conf import *
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -178,11 +178,9 @@ todo_include_todos = False
 # Define standard header/footers.
 
 rst_prolog = ""
-rst_epilog = ""
-renamed_rst_epilog = """
-.. _AstroPy: http://www.astropy.org/
+rst_epilog = """
+.. _astropy: http://www.astropy.org/
 .. _matplotlib: http://matplotlib.org/
-.. _Sphinx: http://sphinx.pocoo.org/
 .. _Sherpa: http://cxc.cfa.harvard.edu/contrib/sherpa/
 """
 

--- a/docs/examples_2d.rst
+++ b/docs/examples_2d.rst
@@ -57,7 +57,6 @@ Here we flatten the arrays and then adjust the error bars for the fit:
     fitmo.amplitude = 50
 
     fitmo = sfit(fitmo, x=x0.flatten(), y=x1.flatten(), z=mexp.flatten()+merr.flatten(),
-                 xbinsize=np.ones(x0.size)*dx, ybinsize=np.ones(x1.size)*dx,
                  err=merr.flatten()+np.random.uniform(-0.5,0.5,x0.size))
 
     plt.subplot(1, 2, 1)
@@ -103,7 +102,6 @@ Here we flatten the arrays and then adjust the error bars for the fit:
 
     fitmo = sfit(fitmo, x0.flatten(), x1.flatten(),
                  mexp.flatten()+merr.flatten(),
-                 xbinsize=np.ones(x0.size)*dx, ybinsize=np.ones(x1.size)*dx,
                  err=merr.flatten()+np.random.uniform(-0.5, 0.5, x0.size))
 
     plt.rcParams['figure.figsize'] = (15, 5)

--- a/docs/examples_complex.rst
+++ b/docs/examples_complex.rst
@@ -1,10 +1,8 @@
-.. include:: references.txt
-
 Usage details
 ==============
 
 Now that you have the basics let's move on to some more complex usage of the fitter interface.
-First a quick preamble to do some imports and create our |SherpaFitter| object.
+First a quick preamble to do some imports and create our `~saba.SherpaFitter` object.
 
 .. doctest-skip::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,19 +4,20 @@ Saba: Sherpa-Astropy Bridge
 The Saba package provides a bridge between the convenient model definition
 language provided in the `astropy.modeling` package and the powerful fitting
 capabilities of the Sherpa_ modeling and fitting package.  In particular,
-Sherpa has a selection of robust optimization algorithms coupled with
-configurable fit statistics.  Once the model fit is complete Sherpa has three
+Sherpa_ has a selection of robust optimization algorithms coupled with
+configurable fit statistics.  Once the model fit is complete Sherpa_ has three
 different ways to estimate parameter confidence intervals, including methods
-that allow for coupled non-gaussian errors.  Finally, Sherpa has an MCMC
+that allow for coupled non-gaussian errors.  Finally, Sherpa_ has an MCMC
 sampler that can be used to generate draws from the probability distribution
 assuming given priors.
 
-Once Saba and Sherpa are installed, the Saba package exposes the above Sherpa
-functionality within the `astropy.modeling.fitting` package via a single
-`~saba.SherpaFitter` class which acts as a fitting backend within astropy.  If
-using the latest version of astropy (development or >= 1.3), a plugin registry
-system automatically makes the `~saba.SherpaFitter` class available within the
-`astropy.modeling.fitting` module without requiring an explicit import.
+Once Saba and Sherpa_ are installed, the Saba package exposes the above
+Sherpa_ functionality within the `astropy.modeling.fitting` package via
+a single `~saba.SherpaFitter` class which acts as a fitting backend
+within astropy. A plugin registry system automatically makes the
+`~saba.SherpaFitter` class available within the
+`astropy.modeling.fitting` module without requiring an explicit
+import.
 
 ``Saba`` is the Sherpa people's word for "bridge".
 
@@ -29,10 +30,10 @@ assume use of the conda + Anaconda package system.
 Prerequisites
 ^^^^^^^^^^^^^
 
- * Python 2.7 (support for Python 3.5+ is in work)
- * numpy
- * astropy
- * sherpa
+ * Python 3.5+
+ * numpy 1.15
+ * astropy_ 2.0 or higher (3.0 or higher recommended, as support for 2.0 will be dropped soon)
+ * sherpa 4.11
 
 
 .. doctest-skip::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ Prerequisites
 ^^^^^^^^^^^^^
 
  * Python 3.5+
- * numpy 1.15
+ * numpy 1.15+
  * astropy_ 2.0 or higher (3.0 or higher recommended, as support for 2.0 will be dropped soon)
  * sherpa 4.11
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,3 @@
-.. include:: references.txt
-
 Saba: Sherpa-Astropy Bridge
 ===========================
 
@@ -15,9 +13,9 @@ assuming given priors.
 
 Once Saba and Sherpa are installed, the Saba package exposes the above Sherpa
 functionality within the `astropy.modeling.fitting` package via a single
-|SherpaFitter| class which acts as a fitting backend within astropy.  If
+`~saba.SherpaFitter` class which acts as a fitting backend within astropy.  If
 using the latest version of astropy (development or >= 1.3), a plugin registry
-system automatically makes the |SherpaFitter| class available within the
+system automatically makes the `~saba.SherpaFitter` class available within the
 `astropy.modeling.fitting` module without requiring an explicit import.
 
 ``Saba`` is the Sherpa people's word for "bridge".
@@ -41,7 +39,7 @@ Prerequisites
 
    conda install numpy
 
-To make use of the entry points plugin registry which automatically makes the |SherpaFitter| class available within `astropy.modeling.fitting` install ``astropy`` version >= 1.3.
+To make use of the entry points plugin registry which automatically makes the `~saba.SherpaFitter` class available within `astropy.modeling.fitting` install ``astropy`` version >= 1.3.
 
 Otherwise one can just use the latest stable ``astropy`` via::
 
@@ -68,8 +66,8 @@ If you are not already familiar with `astropy.modeling`, now is a good time to
 review the introductory documentation there along with the
 `astropy.modeling.fitting` module details.
 
-To start with Saba let's import the |SherpaFitter| class which is the interface
-with Sherpa's fitting routines.  |SherpaFitter| is available in one of
+To start with Saba let's import the `~saba.SherpaFitter` class which is the interface
+with Sherpa's fitting routines.  `~saba.SherpaFitter` is available in one of
 two ways, either directly from `saba` or through `astropy.modeling.fitting`
 through the plugin registry system.  The latter method is preferred but requires
 `astropy` version >= 1.3 or the latest development (master) version.  Use::
@@ -88,7 +86,7 @@ Initialization
 
 To initialize a fitter we provide string values to define the ``statistic``,
 ``optimizer`` and ``estmethod`` (error estimation method).  The available
-values for those can be found in the docstring of |SherpaFitter| and
+values for those can be found in the docstring of `~saba.SherpaFitter` and
 relate to objects within `sherpa.stats`, `sherpa.optmethods` and
 `sherpa.estmethods`.
 
@@ -219,7 +217,7 @@ Now we have a fit we can look at the outputs by doing:
     message        = successful termination
     nfev           = 84
 
-Note that the ``fit_info`` attribute is custom to the |SherpaFitter| class and
+Note that the ``fit_info`` attribute is custom to the `~saba.SherpaFitter` class and
 provides a direct link to the internal fitting results from the Sherpa fit
 process.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ Prerequisites
 ^^^^^^^^^^^^^
 
  * Python 3.5+
- * numpy 1.15+
+ * numpy 1.12+
  * astropy_ 2.0 or higher (3.0 or higher recommended, as support for 2.0 will be dropped soon)
  * sherpa 4.11
 

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -1,2 +1,0 @@
-.. |SherpaFitter| replace:: `~saba.SherpaFitter`
-.. _Sherpa: http://cxc.cfa.harvard.edu/contrib/sherpa/

--- a/saba/__init__.py
+++ b/saba/__init__.py
@@ -10,6 +10,17 @@ Bridge between Sherpa and Astropy modeling.
 from ._astropy_init import *
 # ----------------------------------------------------------------------------
 
+import sys
+
+__minimum_python_version__ = "3.5"
+
+class UnsupportedPythonError(Exception):
+    pass
+
+if sys.version_info < tuple((int(val) for val in __minimum_python_version__.split('.'))):
+    raise UnsupportedPythonError("packagename does not support Python < {}".format(__minimum_python_version__))
+
+
 # For egg_info test builds to pass, put package imports here.
 if not _ASTROPY_SETUP_:
     from .main import SherpaFitter, SherpaMCMC, Stat, OptMethod, EstMethod, Dataset, ConvertedModel

--- a/saba/_astropy_init.py
+++ b/saba/_astropy_init.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-__all__ = ['__version__', '__githash__', 'test']
+__all__ = ['__version__', '__githash__']
 
 # this indicates whether or not we are in the package's setup.py
 try:
@@ -22,98 +22,20 @@ try:
 except ImportError:
     __githash__ = ''
 
-# set up the test command
-def _get_test_runner():
-    import os
-    from astropy.tests.helper import TestRunner
-    return TestRunner(os.path.dirname(__file__))
 
-def test(package=None, test_path=None, args=None, plugins=None,
-         verbose=False, pastebin=None, remote_data=False, pep8=False,
-         pdb=False, coverage=False, open_files=False, **kwargs):
-    """
-    Run the tests using `py.test <http://pytest.org/latest>`__. A proper set
-    of arguments is constructed and passed to `pytest.main`_.
-
-    .. _py.test: http://pytest.org/latest/
-    .. _pytest.main: http://pytest.org/latest/builtin.html#pytest.main
-
-    Parameters
-    ----------
-    package : str, optional
-        The name of a specific package to test, e.g. 'io.fits' or 'utils'.
-        If nothing is specified all default tests are run.
-
-    test_path : str, optional
-        Specify location to test by path. May be a single file or
-        directory. Must be specified absolutely or relative to the
-        calling directory.
-
-    args : str, optional
-        Additional arguments to be passed to pytest.main_ in the ``args``
-        keyword argument.
-
-    plugins : list, optional
-        Plugins to be passed to pytest.main_ in the ``plugins`` keyword
-        argument.
-
-    verbose : bool, optional
-        Convenience option to turn on verbose output from py.test_. Passing
-        True is the same as specifying ``'-v'`` in ``args``.
-
-    pastebin : {'failed','all',None}, optional
-        Convenience option for turning on py.test_ pastebin output. Set to
-        ``'failed'`` to upload info for failed tests, or ``'all'`` to upload
-        info for all tests.
-
-    remote_data : bool, optional
-        Controls whether to run tests marked with @remote_data. These
-        tests use online data and are not run by default. Set to True to
-        run these tests.
-
-    pep8 : bool, optional
-        Turn on PEP8 checking via the `pytest-pep8 plugin
-        <http://pypi.python.org/pypi/pytest-pep8>`_ and disable normal
-        tests. Same as specifying ``'--pep8 -k pep8'`` in ``args``.
-
-    pdb : bool, optional
-        Turn on PDB post-mortem analysis for failing tests. Same as
-        specifying ``'--pdb'`` in ``args``.
-
-    coverage : bool, optional
-        Generate a test coverage report.  The result will be placed in
-        the directory htmlcov.
-
-    open_files : bool, optional
-        Fail when any tests leave files open.  Off by default, because
-        this adds extra run time to the test suite.  Requires the
-        `psutil <https://pypi.python.org/pypi/psutil>`_ package.
-
-    parallel : int, optional
-        When provided, run the tests in parallel on the specified
-        number of CPUs.  If parallel is negative, it will use the all
-        the cores on the machine.  Requires the
-        `pytest-xdist <https://pypi.python.org/pypi/pytest-xdist>`_ plugin
-        installed. Only available when using Astropy 0.3 or later.
-
-    kwargs
-        Any additional keywords passed into this function will be passed
-        on to the astropy test runner.  This allows use of test-related
-        functionality implemented in later versions of astropy without
-        explicitly updating the package template.
-
-    """
-    test_runner = _get_test_runner()
-    return test_runner.run_tests(
-        package=package, test_path=test_path, args=args,
-        plugins=plugins, verbose=verbose, pastebin=pastebin,
-        remote_data=remote_data, pep8=pep8, pdb=pdb,
-        coverage=coverage, open_files=open_files, **kwargs)
-
-if not _ASTROPY_SETUP_:
+if not _ASTROPY_SETUP_:  # noqa
     import os
     from warnings import warn
-    from astropy import config
+    from astropy.config.configuration import (
+        update_default_config,
+        ConfigurationDefaultMissingError,
+        ConfigurationDefaultMissingWarning)
+
+    # Create the test function for self test
+    from astropy.tests.runner import TestRunner
+    test = TestRunner.make_test_runner_in(os.path.dirname(__file__))
+    test.__test__ = False
+    __all__ += ['test']
 
     # add these here so we only need to cleanup the namespace at the end
     config_dir = None
@@ -123,16 +45,16 @@ if not _ASTROPY_SETUP_:
         config_template = os.path.join(config_dir, __package__ + ".cfg")
         if os.path.isfile(config_template):
             try:
-                config.configuration.update_default_config(
+                update_default_config(
                     __package__, config_dir, version=__version__)
             except TypeError as orig_error:
                 try:
-                    config.configuration.update_default_config(
-                        __package__, config_dir)
-                except config.configuration.ConfigurationDefaultMissingError as e:
-                    wmsg = (e.args[0] + " Cannot install default profile. If you are "
+                    update_default_config(__package__, config_dir)
+                except ConfigurationDefaultMissingError as e:
+                    wmsg = (e.args[0] +
+                            " Cannot install default profile. If you are "
                             "importing from source, this is expected.")
-                    warn(config.configuration.ConfigurationDefaultMissingWarning(wmsg))
+                    warn(ConfigurationDefaultMissingWarning(wmsg))
                     del e
-                except:
+                except Exception:
                     raise orig_error

--- a/saba/conftest.py
+++ b/saba/conftest.py
@@ -2,7 +2,17 @@
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 
-from astropy.tests.pytest_plugins import *
+from astropy.version import version as astropy_version
+if astropy_version < '3.0':
+    # With older versions of Astropy, we actually need to import the pytest
+    # plugins themselves in order to make them discoverable by pytest.
+    from astropy.tests.pytest_plugins import *
+else:
+    # As of Astropy 3.0, the pytest plugins provided by Astropy are
+    # automatically made available when Astropy is installed. This means it's
+    # not necessary to import them here, but we still need to import global
+    # variables that are used for configuration.
+    from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 
 ## Uncomment the following line to treat all DeprecationWarnings as
 ## exceptions
@@ -29,12 +39,13 @@ import os
 # This is to figure out the affiliated package version, rather than
 # using Astropy's
 try:
-    from .version import version
+    from .version import version, astropy_helpers_version
 except ImportError:
     version = 'dev'
 
 try:
     packagename = os.path.basename(os.path.dirname(__file__))
     TESTED_VERSIONS[packagename] = version
+    TESTED_VERSIONS['astropy_helpers'] = astropy_helpers_version
 except NameError:   # Needed to support Astropy <= 1.0.0
     pass

--- a/saba/conftest.py
+++ b/saba/conftest.py
@@ -1,11 +1,33 @@
-# this contains imports plugins that configure py.test for astropy tests.
-# by importing them here in conftest.py they are discoverable by py.test
-# no matter how it is invoked within the source tree.
+# This file is used to configure the behavior of pytest when using the Astropy
+# test infrastructure.
 
-from astropy.tests.pytest_plugins import *
+from astropy.version import version as astropy_version
+if astropy_version < '3.0':
+    # With older versions of Astropy, we actually need to import the pytest
+    # plugins themselves in order to make them discoverable by pytest.
+    from astropy.tests.pytest_plugins import *
+else:
+    # As of Astropy 3.0, the pytest plugins provided by Astropy are
+    # automatically made available when Astropy is installed. This means it's
+    # not necessary to import them here, but we still need to import global
+    # variables that are used for configuration.
+    from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 
 ## Uncomment the following line to treat all DeprecationWarnings as
 ## exceptions
+# from astropy.tests.helper import enable_deprecations_as_exceptions
+
+
+## Uncomment the following line to treat all DeprecationWarnings as
+## exceptions. For Astropy v2.0 or later, there are 2 additional keywords,
+## as follow (although default should work for most cases).
+## To ignore some packages that produce deprecation warnings on import
+## (in addition to 'compiler', 'scipy', 'pygments', 'ipykernel', and
+## 'setuptools'), add:
+##     modules_to_ignore_on_import=['module_1', 'module_2']
+## To ignore some specific deprecation warning messages for Python version
+## MAJOR.MINOR or later, add:
+##     warnings_to_ignore_by_pyver={(MAJOR, MINOR): ['Message to ignore']}
 # enable_deprecations_as_exceptions()
 
 # Uncomment and customize the following lines to add/remove entries from

--- a/saba/main.py
+++ b/saba/main.py
@@ -10,9 +10,7 @@ from sherpa.stats import CStat, WStat, Cash
 from sherpa.optmethods import GridSearch, LevMar, MonCar, NelderMead
 from sherpa.estmethods import Confidence, Covariance, Projection
 from sherpa.sim import MCMC
-import warnings
 
-from astropy.extern.six.moves import range
 from astropy.utils import format_doc
 from astropy.utils.exceptions import AstropyUserWarning
 #from astropy.tests.helper import catch_warnings

--- a/saba/main.py
+++ b/saba/main.py
@@ -1,5 +1,3 @@
-from __future__ import (absolute_import, unicode_literals, division,
-                        print_function)
 import numpy as np
 from collections import OrderedDict
 from sherpa.fit import Fit

--- a/saba/main.py
+++ b/saba/main.py
@@ -12,7 +12,6 @@ from sherpa.estmethods import Confidence, Covariance, Projection
 from sherpa.sim import MCMC
 import warnings
 
-from astropy.extern.six.moves import range
 from astropy.utils import format_doc
 from astropy.utils.exceptions import AstropyUserWarning
 #from astropy.tests.helper import catch_warnings

--- a/saba/main.py
+++ b/saba/main.py
@@ -17,17 +17,17 @@ import warnings
 from astropy.extern.six.moves import range
 from astropy.utils import format_doc
 from astropy.utils.exceptions import AstropyUserWarning
-from astropy.tests.helper import catch_warnings
+#from astropy.tests.helper import catch_warnings
 
 
-with catch_warnings(AstropyUserWarning) as warns:
-    """this is to stop the import warning
-    occuring when we import into saba"""
-    from astropy.modeling.fitting import Fitter
-
-for w in warns:
-    if "SherpaFitter" not in w.message.message:
-        warnings.warn(w)
+#with catch_warnings(AstropyUserWarning) as warns:
+#    """this is to stop the import warning
+#    occuring when we import into saba"""
+from astropy.modeling.fitting import Fitter
+#
+#for w in warns:
+#    if "SherpaFitter" not in w.message.message:
+#        warnings.warn(w)
 
 # from astropy.modeling
 

--- a/saba/tests/test_main.py
+++ b/saba/tests/test_main.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, unicode_literals, division,
 
 import numpy as np
 
-from numpy.testing.utils import assert_allclose
+from numpy.testing import assert_allclose
 
 try:
     from sherpa.data import DataSimulFit

--- a/saba/tests/test_main.py
+++ b/saba/tests/test_main.py
@@ -3,10 +3,6 @@
 Module to test fitting routines
 """
 
-from __future__ import (absolute_import, unicode_literals, division,
-                        print_function)
-
-
 import numpy as np
 
 from numpy.testing import assert_allclose

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
+[tool:pytest]
 minversion = 2.2
 norecursedirs = build docs/_build
 doctest_plus = enabled
@@ -23,9 +23,9 @@ long_description = This is a package for fitting astropy models using sherpa
 author = Michele Costa
 author_email = micky.t.costa@gmail.com
 license = GPLv3+
-url = https://github.com/nocturnalastro/saba
+url = https://github.com/astropy/saba
 edit_on_github = False
-github_project = nocturnalastro/saba
+github_project = astropy/saba
 
 
 [entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,23 +3,34 @@ source-dir = docs
 build-dir = docs/_build
 all_files = 1
 
+[build_docs]
+source-dir = docs
+build-dir = docs/_build
+all_files = 1
+
 [upload_docs]
 upload-dir = docs/_build/html
 show-response = 1
 
 [tool:pytest]
-minversion = 2.2
+minversion = 3.0
 norecursedirs = build docs/_build
 doctest_plus = enabled
+addopts = -p no:warnings
 
 [ah_bootstrap]
 auto_use = True
 
+[flake8]
+exclude = extern,sphinx,*parsetab.py
+
+[pycodestyle]
+exclude = extern,sphinx,*parsetab.py
 
 [metadata]
 package_name = saba
-description = Astropy affiliated package
-long_description = This is a package for fitting astropy models using sherpa
+description = SABA - A code to bridge and astropy and sherpa
+long_description = SABA is a code to brigde astropy and and Sherpa modelling and fitting. Both packages provide a a modelling and fitting framework that is in principle compatible, but uses different APIs. SABA translates between the two packages, so that e.g. sherpa models and fitters cna be used inside the astropy modelling framework.
 author = Michele Costa
 author_email = micky.t.costa@gmail.com
 license = GPLv3+
@@ -27,6 +38,13 @@ url = https://github.com/astropy/saba
 edit_on_github = False
 github_project = astropy/saba
 
+# install_requires should be formatted as a comma-separated list, e.g.:
+# install_requires = astropy, scipy, matplotlib
+install_requires = astropy
+# version should be PEP440 compatible (https://www.python.org/dev/peps/pep-0440/)
+version = 0.2.dev
+# Note: you will also need to change this in your package's __init__.py
+minimum_python_version = 3.5
 
 [entry_points]
 

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,6 @@ setup(name=PACKAGENAME,
       long_description=LONG_DESCRIPTION,
       cmdclass=cmdclassd,
       zip_safe=False,
-      use_2to3=False,
       entry_points=entry_points,
       python_requires='>={}'.format(__minimum_python_version__),
       **package_info


### PR DESCRIPTION
The goal of this PR is to update SABA to the current verisions for astropy, et al. Tasks:

- [x] Make sure saba installs and tests with numpy 1.15+, astropy 3+, currrent sphinx etc.
- [x] update astropy helpers
- [x] update travis.yml
- [ ] update setup for rtd
- [x] remove python 2 code (e.g. `__future__` imports) where I see it anyway
- [x] update docs, in particular installation instructions

